### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ i18next.init({
   }
 });
 
-export const i18n = createI18nStore(i18next);
+const i18n = createI18nStore(i18next);
+export default i18n;
 ```
 
 `App.svelte`:


### PR DESCRIPTION
There's a small error in the README, i18n.js needs a default exoprt (or `import { i18n } from './i18n.js'` in App.svelte).