### PR TITLE
Add sveltekit instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,54 @@ export const i18n = createI18nStore(i18next);
 </div>
 ```
 
+## Usage with Sveltekit
+
+Sveltekit shares stores across requests on server-side. This means that one users request could change the language setting of another users rendering if that is still ongoing. To avoid this issue, use `setContext` to create request-scoped store instances:
+
+`i18n.js`:
+```ts
+import i18next from "i18next";
+import { createI18nStore } from "svelte-i18next";
+
+i18next.init({
+ lng: 'en',
+ resources: {
+    en: {
+      translation: {
+        "key": "hello world"
+      }
+    }
+  },
+  interpolation: {
+    escapeValue: false, // not needed for svelte as it escapes by default
+  }
+});
+
+export default () => createI18nStore(i18next);
+```
+
+`routes/+layout.svelte`:
+```sveltehtml
+<script>
+  import getI18nStore from "i18n.js";
+  import { setContext } from "svelte";
+  
+  setContext('i18n', getI18nStore());
+</script>
+```
+
+`routes/+page.svelte`:
+```sveltehtml
+<script>
+  import { getContext } from "svelte";
+  
+  const i18n = getContext("i18n");
+</script>
+
+<div>
+  <h1>{ $i18n.t("key") }</h1>
+</div>
+```
+
 See full example project: [Svelte example](https://github.com/NishuGoel/svelte-i18next/blob/main/example)
 


### PR DESCRIPTION
This PR adds instructions for the use with sveltekit that avoids a [tricky caveat regarding the way that Sveltekit uses stores on serverside](https://kit.svelte.dev/docs/state-management):

On most SSR environments using the store directly – as you would in plain Svelte Apps – means localisation state is unintentionally shared between users.

For most smaller applications this doesn't have any visible effect because localisation state is set at the beginning of the request and the request is completed before another user's request is received.

But in high traffic environments and / or slow rendering pages the following could happen:
- User A has a locale `en`. State is set, the page starts rendering with locale `en`.
- While user A's request is still being rendered on the server, User B makes a request with a different locale, say `cn`. This modifies the global `locale` state.
- User A's request will now finish rendering with locale `cn`!

The Sveltekit docs explicitly state to avoid global stores for this reason:
https://kit.svelte.dev/docs/state-management

Fortunately this library uses i18next's `createInstance` function, so the fix is as easy as just using `getContext` instead of using the store directly.
