### PR TITLE
Fix: sourcemap issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+.idea
 .DS_Store
 node_modules
 *.js
 *.d.ts
 *.map
+.npmrc

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
   "license": "MIT",
   "files": [
     "package.json",
-    "*.js",
-    "*.js.map",
-    "*.d.ts"
+    "**/*.js",
+    "**/*.js.map",
+    "**/*.d.ts",
+    "**/*.ts"
   ],
   "devDependencies": {
     "@jest/types": "^29.5.0",


### PR DESCRIPTION
## Problem Description:

In the context of a Svelte project, the library produced a warning as demonstrated below:
![image (1)](https://github.com/NishuGoel/svelte-i18next/assets/16836689/076f09b3-d6c7-4a69-bb85-234eb5b6addc)

## Proposed Changes:
 - The source code has been incorporated into the published bundle to resolve the aforementioned warning.
 - Updates have been made to the .gitignore file to prevent unintentional publication of IDE-specific files and `.npmrc`.

## Verification:

The changes were tested by:
 - running `npm pack` followed by extraction of the resultant tarball into the node_modules directory of the respective Svelte project. 
 - running `npm publish --dry-run; ` verifying the files for accuracy.